### PR TITLE
[android datepicker] Handle 'cancel'

### DIFF
--- a/src/plugins/datepicker.js
+++ b/src/plugins/datepicker.js
@@ -11,6 +11,8 @@ angular.module('ngCordova.plugins.datePicker', [])
         options = options || {date: new Date(), mode: 'date'};
         $window.datePicker.show(options, function (date) {
           q.resolve(date);
+        }, function(error){
+          q.reject(error);
         });
         return q.promise;
       }


### PR DESCRIPTION
On android, if the dat picker is closed by button ‘cancel’, onError is
triggered according to the plugin doc. In this situation, we should
reject the promise.

datePicker.show(options, onSuccess, onError);
